### PR TITLE
Make ceph.conf template idempotent by sorting hash keys

### DIFF
--- a/templates/ceph.conf.erb
+++ b/templates/ceph.conf.erb
@@ -1,6 +1,6 @@
-<% @_conf.each do |section, setting_value| -%>
+<% @_conf.sort.map do |section, setting_value| -%>
 [<%= section %>]
-<% setting_value.each do |setting, value| -%>
+<% setting_value.sort.map do |setting, value| -%>
   <%= setting %> = <%= value %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Fix problem where puppet recreates ceph.conf on each run.